### PR TITLE
fixed bone calculator

### DIFF
--- a/src/main/java/com/github/elrol/run4lessplugin/BoneCalcPanel.java
+++ b/src/main/java/com/github/elrol/run4lessplugin/BoneCalcPanel.java
@@ -30,7 +30,7 @@ public class BoneCalcPanel extends JPanel {
             boneQty.setText("" + bones);
             int p = parseString(price.getText());
             price.setText("" + p);
-            int total = Math.round((((float)bones) / 26.0F) * (float)p);
+            double total = (Math.floor((((float)bones)) / 26.0F) * (float)p);
             DecimalFormat formatter = new DecimalFormat("#,###");
             totalCost.setText(formatter.format(total));
         });


### PR DESCRIPTION
When the amount of inventories the runner delivers is calculated (via dividing the bone quantity by 26), the quotient rounds down, providing runners with simpler numbers to give to their clients when discussing payments.